### PR TITLE
fix users & forwarded address views always empty

### DIFF
--- a/src/hooks/useForwardedAddress.ts
+++ b/src/hooks/useForwardedAddress.ts
@@ -17,6 +17,7 @@ const useForwadedAddress = (params?: Address.IParams) => {
 		let addressList: any = [];
 		let response = await api.addressApi.getAddresses(
 			_.get(params, 'query', ' '),
+			'',
 			_.get(params, 'tags', ' '),
 			_.get(params, 'requiredTags', ' '),
 			_.get(params, 'metaData', false),
@@ -32,6 +33,7 @@ const useForwadedAddress = (params?: Address.IParams) => {
 		while (!_.isEmpty(_.get(response, 'nextCursor'))) {
 			response = await api.addressApi.getAddresses(
 				_.get(params, 'query', ' '),
+				'',
 				_.get(params, 'tags', ' '),
 				_.get(params, 'requiredTags', ' '),
 				_.get(params, 'metaData', false),

--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -18,6 +18,7 @@ const useUsers = (params?: IUsers.IFilterUsers) => {
 		async () => {
 			const { data } = await api.usersApi.getUsers(
 				params?.query,
+				'',
 				params?.tags,
 				params?.requiredTags,
 				params?.metaData,


### PR DESCRIPTION
there is a new parameter called 'forward' in the address & users endpoints. Current code does not manage it correctly & ends up feeding other parameters with wrong value. End result is the end-point sending back error. 
Fixed it by simply giving it a emptry string value
Not sure that the way to go though , maybe a full management of this new parameter would be best (but I don't know TypeScript...)